### PR TITLE
Add index page with automatic redirect

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Build Compiler User Guide with mdBook
         run: mdbook build
         working-directory: ./compiler-user-guide
+      
+      - name: Add Index Page
+        run: |
+          mkdir public
+          cp index.html ./public/index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="refresh" content="1; url='https://docs.clash-lang.org/compiler-user-guide/'" />
+</head>
+
+<body>
+    <p>You will be redirected to the Clash Compiler User Guide soon!</p>
+</body>
+
+</html>


### PR DESCRIPTION
Maybe this page could link to the different sub-books later on, but for now it's a redirect to the compiler user guide!